### PR TITLE
mediumレベルのレビュー修正をする #52

### DIFF
--- a/src/app/presentation/components/checkoutWithText.tsx
+++ b/src/app/presentation/components/checkoutWithText.tsx
@@ -6,7 +6,7 @@ import showAlertForCheckout from "@/app/utility/showAlertForCheckout";
 import UserRadioButtons from "./parts/userRadioButtons";
 
 function CheckoutWithText() {
-  const [userName, setUserName] = useState<string>("");
+  const [userName, setUserName] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
 
@@ -73,7 +73,10 @@ function CheckoutWithText() {
               onTouchEnd={openModal}
             ></span>
           </div>
-            <UserRadioButtons handleChange={handleRadioChange}></UserRadioButtons>
+            <UserRadioButtons 
+              handleChange={handleRadioChange}
+              selectedValue={userName}
+            ></UserRadioButtons>
           <div className={checkoutWithTextStyle.modalField}>
             <textarea
               name="text"

--- a/src/app/presentation/components/parts/userRadioButtons.tsx
+++ b/src/app/presentation/components/parts/userRadioButtons.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from "react";
 
 interface UserRadioButtonsProps {
     handleChange: (userName: string) => void;
+    // Reactの推奨パターンに従い、ブラウザのデフォルト動作に依存せず、コンポーネントの状態を明示的に制御するために追加
+    selectedValue?: string | null;
 }
 
-export default function UserRadioButtons({ handleChange}: UserRadioButtonsProps): JSX.Element {
+export default function UserRadioButtons({ handleChange, selectedValue = null}: UserRadioButtonsProps): JSX.Element {
     const [name1, setName1] = useState<string>("");
     const [name2, setName2] = useState<string>("");
     
@@ -14,7 +16,7 @@ export default function UserRadioButtons({ handleChange}: UserRadioButtonsProps)
       }, []);
 
     const handleRadioChange  = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const userName: string = event.target.value;
+        const userName: string = event.target.value;
         handleChange(userName);
     };
 
@@ -33,12 +35,24 @@ export default function UserRadioButtons({ handleChange}: UserRadioButtonsProps)
       <div id="userRadioButtons" style={marginBottom}>
         {name1 && (
           <label style={textStyle}>
-            <input type="radio" name="user" value={name1} onChange={handleRadioChange} /> {name1}
+            <input 
+              type="radio" 
+              name="user" 
+              value={name1} 
+              onChange={handleRadioChange}
+              checked={selectedValue === name1}
+            /> {name1}
           </label>
         )}
         {name2 && (
           <label style={textStyle}>
-              <input type="radio" name="user" value={name2} onChange={handleRadioChange} /> {name2}
+              <input 
+                type="radio" 
+                name="user" 
+                value={name2} 
+                onChange={handleRadioChange}
+                checked={selectedValue === name2}
+              /> {name2}
             </label>
         )}
       </div>

--- a/src/app/presentation/components/sendCheckout.client.tsx
+++ b/src/app/presentation/components/sendCheckout.client.tsx
@@ -17,7 +17,10 @@ function SendCheckout() {
 
   return (
     <div>
-      <UserRadioButtons handleChange={handleRadioChange}></UserRadioButtons>
+      <UserRadioButtons 
+        handleChange={handleRadioChange}
+        selectedValue={userName}
+      ></UserRadioButtons>
         <button
       className={checckoutStyles.checkoutButton}
       id="checkout"


### PR DESCRIPTION
TODO
https://github.com/t1k2a/leaving-work/pull/51#discussion_r2109396763
```
userName の状態が string | null (初期値 null) から string (初期値 "") に変更されましたね。これにより、未選択状態が "" で表現されるようになったと理解しました。

一方で、sendCheckout.client.tsx の userName は依然として string | null (初期値 null) で管理されています (該当ファイルL9)。UserRadioButtons から渡される userName は string型（環境変数が未設定で name1 や name2 が空文字列の場合は "" になり得ます）であるため、このファイルでの string 型への変更は合理的です。

アプリケーション全体でユーザー未選択時の状態表現（"" を使うか null を使うか）を統一することを検討してみてはいかがでしょうか？例えば、sendCheckout.client.tsx も useState<string>("") に初期化を合わせるなどです。これにより、コードの予測可能性が高まり、潜在的な混乱を避けることができます。
```

https://github.com/t1k2a/leaving-work/pull/51#discussion_r2109396771
```
UserRadioButtonsProps から userName プロパティが削除され、handleChange の型シグネチャが (userName: string) => void に変更されましたね。このコンポーネントは以前のバージョンでも受け取った userName を使ってラジオボタンの checked 状態を直接制御していなかったため、この変更によって既存の表示機能に大きな変化はないかもしれません。

しかし、もし親コンポーネントが持つ userName の値に基づいて特定のラジオボタンを初期状態で選択済みにしたいという要件がある場合（例：以前のセッションで選択したユーザーを復元する場合など）、将来的には selectedValue のようなプロパティを新たに追加し、各 <input> 要素で checked={props.selectedValue === name1} のように明示的に checked 状態を制御する必要が出てくる可能性があります。

現在の実装では、ラジオボタンの選択状態はブラウザのデフォルト動作に依存し、handleChange を通じて選択された値を親に通知する形になっています。この設計方針で問題ないか、将来的な拡張性も考慮して確認しておくと良いでしょう。
```
