### PR TITLE
AIメッセージの透過度を調整

### DIFF
--- a/src/app/presentation/components/checkoutWithText.tsx
+++ b/src/app/presentation/components/checkoutWithText.tsx
@@ -81,7 +81,11 @@ function CheckoutWithText({ onModalOpen, onModalClose }: CheckoutWithTextProps) 
             {inputValue && (
               <div className={checkoutWithTextStyle.modalPreview}>
                 <p className={checkoutWithTextStyle.previewTitle}>↓ プレビュー</p>
-                <p className={checkoutWithTextStyle.previewMessage}>{userName? userName + "が、" : ""}{preViewTime}:退勤しました！</p>
+                <p
+                  className={`${checkoutWithTextStyle.previewMessage} ${isOpen ? checkoutWithTextStyle.dimmed : ""}`}
+                >
+                  {userName? userName + "が、" : ""}{preViewTime}:退勤しました！
+                </p>
                 <p className={checkoutWithTextStyle.previewText}>追加テキスト：</p>
                 <p className={checkoutWithTextStyle.previewText}>{inputValue}</p>
               </div>

--- a/src/app/presentation/styles/checkoutWithText.module.css
+++ b/src/app/presentation/styles/checkoutWithText.module.css
@@ -116,6 +116,10 @@
   line-height: 1.4;
 }
 
+.dimmed {
+  opacity: 0.2;
+}
+
 .previewText {
   font-weight: bold;
   color: #333;


### PR DESCRIPTION
## 概要
- テキスト退勤ボタン押下時にAIメッセージを透過

## テスト
- `npm test` (script missing)
- `npm run lint` (`next` not found)
- `npm install` (MaxListenersExceededWarning)


------
https://chatgpt.com/codex/tasks/task_e_688ad1596404832aa02ba7fd35bda553