### PR TITLE
Speed up boss spawn

### DIFF
--- a/public/game/index.html
+++ b/public/game/index.html
@@ -984,7 +984,7 @@
             if (!bossActive && !boss && !gameCompleted) {
                 if (!showBossIntro) {
                     showBossIntroduction();
-                } else if (Date.now() - bossIntroTimer > 2000) {
+                } else if (Date.now() - bossIntroTimer > 1000) {
                     createBoss();
                     showBossIntro = false;
                 }


### PR DESCRIPTION
## Summary
- Reduce boss intro wait from 2s to 1s so bosses appear faster

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891670679e0832aa76530845a0b80c6