### PR TITLE
Add commute API and integrate arrival time into Gemini messages

### DIFF
--- a/src/app/presentation/components/autoGeminiMessage.tsx
+++ b/src/app/presentation/components/autoGeminiMessage.tsx
@@ -12,6 +12,7 @@ interface GeminiResponse {
 export default function AutoGeminiMessage() {
     const [message, setMessage] = useState<string>("");
     const [isLoading, setIsLoading] = useState(true);
+    const [loadingText, setLoadingText] = useState('通勤情報を取得中...');
     const [error, setError] = useState(false);
 
     useEffect(() => {
@@ -20,7 +21,15 @@ export default function AutoGeminiMessage() {
 
     const fetchGeminiMessage = async () => {
         try {
-            const response = await fetch('/api/geminiAPI', {
+            setLoadingText('通勤情報を取得中...');
+            const commuteRes = await fetch('/api/commute');
+            if (!commuteRes.ok) {
+                throw new Error(`Commute API error: ${commuteRes.status}`);
+            }
+            const commuteData = await commuteRes.json();
+
+            setLoadingText('メッセージを生成中...');
+            const response = await fetch(`/api/geminiAPI?station=${encodeURIComponent(commuteData.station)}&arrivalTime=${encodeURIComponent(commuteData.arrivalTime)}`, {
                 method: 'GET',
                 headers: {
                     'Content-Type': 'application/json',
@@ -47,7 +56,7 @@ export default function AutoGeminiMessage() {
             <div className={styles.container}>
                 <div className={styles.loadingMessage}>
                     <div className={styles.spinner}></div>
-                    <span>今日の労いメッセージを取得中...</span>
+                    <span>{loadingText}</span>
                 </div>
             </div>
         );

--- a/src/pages/api/commute.ts
+++ b/src/pages/api/commute.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const address = typeof req.query.address === 'string' ? req.query.address : process.env.WORK_ADDRESS;
+  if (!address) {
+    return res.status(400).json({ error: 'address is required' });
+  }
+
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Missing Google Maps API key' });
+  }
+
+  try {
+    const geocodeRes = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${apiKey}`);
+    const geocodeData = await geocodeRes.json();
+    const location = geocodeData.results?.[0]?.geometry?.location;
+    if (!location) {
+      throw new Error('Unable to geocode address');
+    }
+
+    const placeRes = await fetch(
+      `https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${location.lat},${location.lng}&radius=1000&type=train_station&key=${apiKey}`
+    );
+    const placeData = await placeRes.json();
+    const stationInfo = placeData.results?.[0];
+    if (!stationInfo) {
+      throw new Error('No nearby station found');
+    }
+    const station = stationInfo.name;
+    const stationLoc = stationInfo.geometry.location;
+
+    const directionsRes = await fetch(
+      `https://maps.googleapis.com/maps/api/directions/json?origin=${location.lat},${location.lng}&destination=${stationLoc.lat},${stationLoc.lng}&mode=walking&key=${apiKey}`
+    );
+    const directionsData = await directionsRes.json();
+    const durationSec = directionsData.routes?.[0]?.legs?.[0]?.duration?.value || 0;
+    const arrivalTime = new Date(Date.now() + durationSec * 1000).toISOString();
+
+    return res.status(200).json({ station, arrivalTime });
+  } catch (err) {
+    console.error('Commute API error:', err);
+    return res.status(500).json({ error: 'Failed to fetch commute info' });
+  }
+}

--- a/src/pages/api/geminiAPI.ts
+++ b/src/pages/api/geminiAPI.ts
@@ -21,7 +21,7 @@ export interface GeminiResponse {
 async function geminiAPImain(prompt?: string): Promise<string> {
   const quickPrompts = [
     "疲れた人への優しい一言。年上男性の穏やかな労りで。",
-    "仕事終わりの癒しの言葉。疲れた人に友達風でゆるく寄り添う癒しの言葉を。", 
+    "仕事終わりの癒しの言葉。疲れた人に友達風でゆるく寄り添う癒しの言葉を。",
   ];
 
   const instruction = "を一言で答えて";
@@ -49,8 +49,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    // Gemini APIを直接呼び出し
-    const text = await geminiAPImain();
+    const station = typeof req.query.station === 'string' ? req.query.station : undefined;
+    const arrivalTime = typeof req.query.arrivalTime === 'string' ? req.query.arrivalTime : undefined;
+
+    const prompt = station && arrivalTime
+      ? `疲れた人への優しい一言。勤務先から${station}まで${arrivalTime}に到着します`
+      : undefined;
+
+    const text = await geminiAPImain(prompt);
         
     return res.status(200).json({ 
       text,


### PR DESCRIPTION
## Summary
- build `/api/commute` endpoint that uses Google Maps services to find a workplace's nearest station and estimated arrival time
- extend `/api/geminiAPI` to accept commute details and generate tailored messages
- update AutoGeminiMessage component to fetch commute info, call Gemini API, and show stepwise loading states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a9a8e42f4832aabb38249be80ed50